### PR TITLE
Add missing statement in Android README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Override `onActivityResult()`.
 ```java
 @Override
 public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
     mCallbackManager.onActivityResult(requestCode, resultCode, data);
 }
 ```


### PR DESCRIPTION
Overrided onActivityResult should calls super.onActivityResult
